### PR TITLE
Fixed GitHub logo.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -115,7 +115,7 @@
             <p>Report a bug in an app</p>
         </a>
         <a class="headerItem" onclick="$('#projectsMenu').toggleClass('open');" href="https://github.com/vicr123/">
-            <img class="appIcon" src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png">
+            <img class="appIcon" src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png">
             <p class="title">GitHub</p>
             <p>Code Repositories</p>
         </a>


### PR DESCRIPTION
This is just an update of the icon's link, as GitHub moved their CDN. This was first brought up in #11 by me and I decided to fix it.